### PR TITLE
fix: use real wslg.exe

### DIFF
--- a/config.py
+++ b/config.py
@@ -262,7 +262,7 @@ def configure_windows(keymap) -> None:
     keymap_global["W-n"] = run_or_raise(
         keymap,
         check_func=check_func_emacs,
-        command="wslg.exe",
+        command=str(program_files("WSL", "wslg.exe")),
         param="--cd ~ -d Ubuntu -- emacs",
     )
     keymap_global["W-Minus"] = run_or_raise(keymap, exe_name="slack.exe")


### PR DESCRIPTION
[Update the path of wslg.exe for the new MSI package. by benhillis · Pull Request #1124 · microsoft/wslg](https://github.com/microsoft/wslg/pull/1124) の変更でWSLgの本物の場所がパスが通った場所から変動したことへの対応。

keyhacから呼び出すと以下のようなエラーになっていたのを修正。

~~~
Traceback (most recent call last):
  File "../ckit\ckit_threadutil.py", line 231, in run
  File ".\keyhac_keymap.py", line 2161, in jobShellExecute
FileNotFoundError: [WinError 2] 指定されたファイルが見つかりません。 
~~~