### PR TITLE
feat!: Slackのアクティベートキーを`W-Minus`から`W-s`に変更

### DIFF
--- a/config.py
+++ b/config.py
@@ -265,7 +265,7 @@ def configure_windows(keymap) -> None:
         command=str(program_files("WSL", "wslg.exe")),
         param="--cd ~ -d Ubuntu -- emacs",
     )
-    keymap_global["W-Minus"] = run_or_raise(keymap, exe_name="slack.exe")
+    keymap_global["W-s"] = run_or_raise(keymap, exe_name="slack.exe")
     keymap_global["W-b"] = run_or_raise(
         keymap,
         exe_name="KeePassXC.exe",


### PR DESCRIPTION
前はここはmikutterの席でした。
Twitter(X)のAPIの原則非公開化に伴いmikutterを使うのは著しく困難になりました。
TweetDeck(X Pro)の単体アプリ化をして使うか悩みましたが、
別にそんなに使うことも無いしむしろ仕事の邪魔になるなと思ってまだやっていません。
よりよく使うSlackのアクティベートキーをホームポジションの`W-s`に変更しました。
SでSlackの名前とも繋がってわかりやすい。
X Proを単体アプリ化して使うとしても`W-Minus`の方にすると思います。