### PR TITLE
build: update Python version to 3.13 in pyright config

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,4 +1,4 @@
 {
-  "pythonVersion": "3.8",
+  "pythonVersion": "3.13",
   "pythonPlatform": "All"
 }


### PR DESCRIPTION
KeyHac 1.83がPython 3.13に移行したため。
